### PR TITLE
multiple_ports: Let Each Peer Have Multiple Ports

### DIFF
--- a/src/network/decoder.rs
+++ b/src/network/decoder.rs
@@ -13,7 +13,6 @@ static COMMANDS: phf::Map<&'static str, &'static str> = phf_map! {
     "00000011" => "ports_response",
     "00000100" => "termination",
     "00000101" => "transaction",
-    "00000110" => "ACK",
 };
 
 pub fn decode_command(msg: &Frame) -> (String, u32, u32) {

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -53,16 +53,21 @@ pub fn get_peerid_response(destid: u32) -> Frame {
     return Frame::Array(response_vec);
 }
 
-pub fn get_ports_query(sourceid: u32, ports: Vec<String>) -> Frame {
-    let header_frame = get_header(sourceid, 1, String::from("00000010"));
+pub fn get_ports_query(sourceid: u32, destid: u32, ports: Vec<String>) -> Frame {
+    let header_frame = get_header(sourceid, destid, String::from("00000010"));
     let ports_frame = Frame::Bulk(Bytes::from(serde_json::to_string(&ports).unwrap()));
     return Frame::Array(Vec::from([header_frame, ports_frame]));
 }
 
-pub fn get_ports_response(ip_map_json: String, port_map_json: String, destid: u32) -> Frame {
+pub fn get_ports_response(
+    sourceid: u32,
+    destid: u32,
+    ip_map_json: String,
+    port_map_json: String,
+) -> Frame {
     let mut response_vec: Vec<Frame> = Vec::new();
 
-    let header_frame = get_header(1, destid, String::from("00000011"));
+    let header_frame = get_header(sourceid, destid, String::from("00000011"));
     response_vec.push(header_frame);
 
     let ip_frame = Frame::Bulk(Bytes::from(ip_map_json));
@@ -91,9 +96,4 @@ pub fn get_transaction_msg(sourceid: u32, destid: u32, tx: Transaction) -> Frame
     let payload = Frame::Bulk(Bytes::from(serde_json::to_string(&tx).unwrap()));
     response_vec.push(payload);
     return Frame::Array(response_vec);
-}
-
-pub fn get_ack_msg(sourceid: u32, destid: u32) -> Frame {
-    let header_frame = get_header(sourceid, destid, String::from("00000110"));
-    return Frame::Array(Vec::from([header_frame]));
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -92,23 +92,9 @@ pub async fn shell() {
             }
             "transaction" | "tx" | "-t" => {
                 let peerid = peer.peerid;
-
-                let mut selected_port = None;
-                for port in &peer.ports {
-                    if scan_port(port.parse::<u16>().unwrap()) {
-                        selected_port = Some(port.to_string());
-                        break;
-                    }
-                }
-                if selected_port.is_none() {
-                    warn!("No available ports for sending a transaction. Aborted.");
-                    continue;
-                }
-
-                let socket = peer.address.to_owned() + ":" + &selected_port.unwrap();
                 let frame =
                     messages::get_transaction_msg(peerid, peerid, get_example_transaction());
-                peer::send_transaction(frame, socket, peerid, peerid).await;
+                peer::send_transaction(frame, peer.address.to_owned(), peer.ports.to_owned()).await;
             }
             "exit" | "Exit" | "EXIT" => {
                 info!("The user selected exit");


### PR DESCRIPTION
- Use ports queries and responses instead of socket queries. Send a query with a message that contains all the updated ports to the server. Make the server send the streams ip and the retrieved ports to the server manager that responds with the ip map from peer ids to ports and the port map with ips to a vector of ports. Make the server send these back to the peer so it can set it's fields. Update decoding functions accordingly.
- Create a get_connection() function in src/network/peer.rs to try to connect to an ip with a certain number of ports
- Create a listen() function in src/network/server.rs to handle listening to connections on multiple ports
- Adjust new transaction message code to allow for ips with multiple ports