### PR TITLE
**DRAFT** Create Transaction Using CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod performance_tests;
 mod shell;
 mod simulation;
 mod utils;
-mod wallet;
 use crate::{network::server::Server, shell::shell};
 use log::info;
 use std::env::{self};

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,7 +10,6 @@ use crate::utils::graph::create_block_graph;
 use crate::utils::hash;
 use crate::utils::save_and_load::{deserialize_json, load_object, save_object};
 use crate::utils::sign_and_verify::{self, PrivateKey, PublicKey, Verifier};
-use crate::wallet::Wallet;
 use chrono::Local;
 use ed25519_dalek::Keypair;
 use local_ip_address::local_ip;
@@ -19,6 +18,7 @@ use port_scanner::scan_port;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::process::exit;
@@ -39,6 +39,60 @@ pub async fn shell(is_miner: bool) {
     }
 
     info!("Successfully launched peer!");
+
+    // Give the peer a chance to see what a transaction.json file looks like
+    loop {
+        info!(
+        "In this system you can include your own transaction.json file under the 'account' folder in the root. Would you like to see what
+        a template transaction.json file looks like? y/n"
+    );
+        let mut choice_display: String = String::new();
+        io::stdin()
+            .read_line(&mut choice_display)
+            .expect("Failed to read line");
+
+        match choice_display.to_lowercase().trim() {
+            "y" => {
+                let dirname = String::from("account");
+                let object_name = String::from("transaction");
+
+                let example_transaction = get_example_transaction();
+                save_object(
+                    &example_transaction,
+                    String::from("transaction"),
+                    String::from("account"),
+                );
+
+                let slash = if env::consts::OS == "windows" {
+                    "\\"
+                } else {
+                    "/"
+                };
+                let mut file = File::open(dirname + slash + &object_name + ".json")
+                    .expect("Failed to open file");
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)
+                    .expect("Failed to read file");
+
+                let json_data: serde_json::Value =
+                    serde_json::from_str(&contents).expect("Failed to parse JSON");
+
+                println!("{}", serde_json::to_string_pretty(&json_data).unwrap());
+                break;
+            }
+
+            "n" => {
+                info!("You selected no.");
+                break;
+            }
+
+            _ => {
+                warn!("Invalid Command. You can only choose y or n.");
+            }
+        }
+    }
+
+    info!("You can now select a command in the shell");
 
     loop {
         let mut command = String::new();
@@ -127,7 +181,7 @@ pub async fn shell(is_miner: bool) {
 
                 // This is a test for loading the transaction and broadcatsing it. It creates wallet.json
                 let (private_key_initial, public_key_initial) = sign_and_verify::create_keypair();
-                let values = vec![(
+                let wallet: Vec<(PrivateKey, PublicKey, Outpoint, u32)> = vec![(
                     private_key_initial,
                     public_key_initial,
                     Outpoint {
@@ -136,111 +190,90 @@ pub async fn shell(is_miner: bool) {
                     },
                     500,
                 )];
-                let wallet: Wallet = Wallet(values);
                 save_object(&wallet, String::from("wallet"), String::from("system"));
 
-                // start of the transaction creator
-                info!("Would you like to load a transaction from a file (f) or create it manually (m)?");
-                let mut choice = String::new();
-                io::stdin()
-                    .read_line(&mut choice)
-                    .expect("Failed to read line");
+                loop {
+                    // start of the transaction creator
+                    info!("Would you like to load a transaction from a file (f) or create it manually (m)?");
+                    let mut choice = String::new();
+                    io::stdin()
+                        .read_line(&mut choice)
+                        .expect("Failed to read line");
 
-                match choice.to_lowercase().trim() {
-                    // In this case, we simply need to be provided with a transaction.json file that we deserialize and directly send the transaction
-                    "f" => {
-                        transaction =
-                            load_object(String::from("transaction"), String::from("account"));
-                        info!("{:?}", transaction.tx_outputs[0].value);
-                    }
-                    "m" => {
-                        // In this case, we need to be provided with a wallet.json file which we deserialize to obtain certain
-                        // parameters (public, private keys) we need to create our transaction
-                        let wallet: Wallet =
-                            load_object(String::from("wallet"), String::from("system"));
+                    match choice.to_lowercase().trim() {
+                        // In this case, we simply need to be provided with a transaction.json file that we deserialize and directly send the transaction
+                        "f" => {
+                            transaction =
+                                load_object(String::from("transaction"), String::from("account"));
+                            info!("{:?}", transaction.tx_outputs[0].value);
+                            break;
+                        }
+                        "m" => {
+                            // In this case, we need to be provided with a wallet.json file which we deserialize to obtain certain
+                            // parameters (public, private keys) we need to create our transaction
+                            let wallet: Vec<(PrivateKey, PublicKey, Outpoint, u32)> =
+                                load_object(String::from("wallet"), String::from("system"));
 
-                        // We will obtain the indices of wallet entries to only select certain keys and their outpoints
-                        info!(
+                            // We will obtain the indices of wallet entries to only select certain keys and their outpoints
+                            info!(
                             "Enter the indices of wallet entries you would like to enter delimited by a comma (e.g., 4,6,8,9) "
                         );
-                        let mut indices = Vec::new();
-                        let mut indices_out: String = String::new();
-                        io::stdin()
-                            .read_line(&mut indices_out)
-                            .expect("Failed to read line");
-                        let trimmed_indices = indices_out.trim();
-                        for s in trimmed_indices.split(',') {
-                            if let Ok(n) = s.trim().parse::<usize>() {
-                                indices.push(n);
+                            let mut indices = Vec::new();
+                            let mut indices_out: String = String::new();
+                            io::stdin()
+                                .read_line(&mut indices_out)
+                                .expect("Failed to read line");
+                            let trimmed_indices = indices_out.trim();
+                            for s in trimmed_indices.split(',') {
+                                if let Ok(n) = s.trim().parse::<usize>() {
+                                    indices.push(n);
+                                }
                             }
-                        }
 
-                        // We create the tx_inputs
-                        for i in indices {
-                            let (private_key, public_key, outpoint, value_from_outpoint) =
-                                wallet.0[i].clone();
+                            // We create the tx_inputs
+                            for i in indices {
+                                let (private_key, public_key, outpoint, value_from_outpoint) =
+                                    wallet[i].clone();
 
-                            let tx_out: TxOut = TxOut {
-                                value: value_from_outpoint,
-                                pk_script: PublicKeyScript {
-                                    public_key_hash: hash::hash_as_string(&public_key),
-                                    verifier: Verifier {},
-                                },
-                            };
+                                let tx_out: TxOut = TxOut {
+                                    value: value_from_outpoint,
+                                    pk_script: PublicKeyScript {
+                                        public_key_hash: hash::hash_as_string(&public_key),
+                                        verifier: Verifier {},
+                                    },
+                                };
 
-                            let message = String::from(&outpoint.txid)
-                                + &outpoint.index.to_string()
-                                + &tx_out.pk_script.public_key_hash;
+                                let message = String::from(&outpoint.txid)
+                                    + &outpoint.index.to_string()
+                                    + &tx_out.pk_script.public_key_hash;
 
-                            let sig_script = SignatureScript {
-                                signature: sign_and_verify::sign(
-                                    &message,
-                                    &private_key,
-                                    &public_key,
-                                ),
-                                full_public_key: public_key,
-                            };
+                                let sig_script = SignatureScript {
+                                    signature: sign_and_verify::sign(
+                                        &message,
+                                        &private_key,
+                                        &public_key,
+                                    ),
+                                    full_public_key: public_key,
+                                };
 
-                            let tx_in: TxIn = TxIn {
-                                outpoint,
-                                sig_script,
-                            };
+                                let tx_in: TxIn = TxIn {
+                                    outpoint,
+                                    sig_script,
+                                };
 
-                            transaction.tx_inputs.append(&mut vec![tx_in]);
-                        }
+                                transaction.tx_inputs.append(&mut vec![tx_in]);
+                            }
 
-                        // We need the recipients to create the tx_outputs
-                        info!(
+                            // We need the recipients to create the tx_outputs
+                            info!(
                             "Enter the number of receipients you would like for your transaction: "
                         );
-                        let mut str_out: String = String::new();
-                        io::stdin()
-                            .read_line(&mut str_out)
-                            .expect("Failed to read line");
-                        let trimmed_out = str_out.trim();
-                        let num_out = match trimmed_out.parse::<u32>() {
-                            Ok(i) => i,
-                            Err(..) => {
-                                error!("Period needs to be a u64");
-                                panic!();
-                            }
-                        };
-
-                        // We create the tx_outputs
-                        for _i in 0..num_out {
-                            info!("Enter the hash of the public key associated with the next recipient:");
-                            let mut public_key = String::new();
+                            let mut str_out: String = String::new();
                             io::stdin()
-                                .read_line(&mut public_key)
+                                .read_line(&mut str_out)
                                 .expect("Failed to read line");
-
-                            info!("Enter the value associated with the next recipient:");
-                            let mut str_value: String = String::new();
-                            io::stdin()
-                                .read_line(&mut str_value)
-                                .expect("Failed to read line");
-                            let trimmed_value = str_value.trim();
-                            let value = match trimmed_value.parse::<u32>() {
+                            let trimmed_out = str_out.trim();
+                            let num_out = match trimmed_out.parse::<u32>() {
                                 Ok(i) => i,
                                 Err(..) => {
                                     error!("Period needs to be a u64");
@@ -248,20 +281,43 @@ pub async fn shell(is_miner: bool) {
                                 }
                             };
 
-                            let tx_out: TxOut = TxOut {
-                                value,
-                                pk_script: PublicKeyScript {
-                                    public_key_hash: hash::hash_as_string(&public_key),
-                                    verifier: Verifier {},
-                                },
-                            };
+                            // We create the tx_outputs
+                            for _i in 0..num_out {
+                                info!("Enter the hash of the public key associated with the next recipient:");
+                                let mut public_key = String::new();
+                                io::stdin()
+                                    .read_line(&mut public_key)
+                                    .expect("Failed to read line");
 
-                            transaction.tx_outputs.append(&mut vec![tx_out]);
+                                info!("Enter the value associated with the next recipient:");
+                                let mut str_value: String = String::new();
+                                io::stdin()
+                                    .read_line(&mut str_value)
+                                    .expect("Failed to read line");
+                                let trimmed_value = str_value.trim();
+                                let value = match trimmed_value.parse::<u32>() {
+                                    Ok(i) => i,
+                                    Err(..) => {
+                                        error!("Period needs to be a u64");
+                                        panic!();
+                                    }
+                                };
+
+                                let tx_out: TxOut = TxOut {
+                                    value,
+                                    pk_script: PublicKeyScript {
+                                        public_key_hash: hash::hash_as_string(&public_key),
+                                        verifier: Verifier {},
+                                    },
+                                };
+
+                                transaction.tx_outputs.append(&mut vec![tx_out]);
+                            }
+                            break;
                         }
-                    }
-                    _ => {
-                        warn!("Invalid Command");
-                        exit(0);
+                        _ => {
+                            warn!("Invalid Command");
+                        }
                     }
                 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,0 @@
-use crate::components::transaction::Outpoint;
-use crate::utils::sign_and_verify::{PrivateKey, PublicKey};
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Wallet(pub Vec<(PrivateKey, PublicKey, Outpoint, u32)>);


### PR DESCRIPTION
We provide the user with 2 options:
- Have a file that serializes an entire transaction (transaction.json in the example in the shell), deserialize it and broadcast the transaction.
- Have a JSON file serializing a wallet which is a vector of public, private keys and their associated outpoint and value (wallet.json in the example in the shell), deserialize it, extract the tx_inputs and outputs, create the transaction, and brodcast it.  