### PR TITLE
merkle parallel vs sequential test parallel gives ~ 2x speedup (On my machine)

### DIFF
--- a/src/components/merkle.rs
+++ b/src/components/merkle.rs
@@ -79,8 +79,8 @@ impl Merkle {
 
         let hashes = Merkle::parallel_hash(transactions, num_cpus::get());
         // Load the hashes into queue1
-        for tx in transactions {
-            queue.push_back(hash_as_string(&tx));
+        for hash in hashes {
+            queue.push_back(hash);
         }
 
         while queue.len() > 1 {

--- a/src/performance_tests/merkle_creation.rs
+++ b/src/performance_tests/merkle_creation.rs
@@ -1,0 +1,82 @@
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
+
+    use itertools::izip;
+    use rand_1::rngs::ThreadRng;
+
+    use crate::{
+        components::{
+            merkle::{self, Merkle},
+            transaction::{Outpoint, PublicKeyScript, Transaction, TxOut},
+            utxo::UTXO,
+        },
+        simulation::KeyMap,
+        utils::{
+            hash,
+            sign_and_verify::{self, Verifier},
+        },
+    };
+
+    fn get_transactions(num: u32) -> Vec<Transaction> {
+        let mut utxo: UTXO = UTXO(HashMap::new());
+        let mut key_map: KeyMap = KeyMap(HashMap::new());
+        let mut transactions: Vec<Transaction> = Vec::new();
+        let (private_key0, public_key0) = sign_and_verify::create_keypair();
+        let outpoint0: Outpoint = Outpoint {
+            txid: "0".repeat(64),
+            index: 0,
+        };
+
+        let tx_out0: TxOut = TxOut {
+            value: 500,
+            pk_script: PublicKeyScript {
+                public_key_hash: hash::hash_as_string(&public_key0),
+                verifier: Verifier {},
+            },
+        };
+
+        key_map.insert(outpoint0.clone(), (private_key0, public_key0));
+        utxo.insert(outpoint0, tx_out0);
+
+        let mut rng: ThreadRng = rand_1::thread_rng();
+        let max_num_outputs = 1;
+        let mut utxo_copy = utxo.clone();
+        for _ in 0..num {
+            let transaction = Transaction::create_transaction(
+                &utxo,
+                &mut key_map,
+                &mut rng,
+                max_num_outputs,
+                false,
+            );
+            utxo.update(&transaction);
+            transactions.push(transaction);
+        }
+        return transactions;
+    }
+
+    #[ignore]
+    #[test]
+    fn test_merkle_performance() {
+        println!("Num CPUs: {}", num_cpus::get());
+        let mut num_transactions = 1;
+        let mut performance_results: Vec<Duration> = Vec::new();
+        let mut num_transactions_vec: Vec<u32> = Vec::new();
+        for _i in 0..=16 {
+            let transactions = get_transactions(num_transactions);
+            let start = Instant::now();
+            Merkle::create_merkle_tree(&transactions);
+            let duration = start.elapsed();
+            performance_results.push(duration);
+            num_transactions_vec.push(num_transactions);
+            num_transactions = num_transactions * 2;
+        }
+
+        println!("{:?}", num_transactions_vec);
+        println!("{:?}", performance_results);
+    }
+}

--- a/src/performance_tests/mod.rs
+++ b/src/performance_tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod block_validation;
 pub mod input_and_output;
+pub mod merkle_creation;
 pub mod throughput;
 pub mod utxo_search;


### PR DESCRIPTION
Parallel results:

Number of transactions: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
Time to create merkle tree: [135.167µs, 134.542µs, 317.708µs, 465.083µs, 803.834µs, 1.134834ms, 1.787625ms, 3.417375ms, 6.89675ms, 13.706583ms, 26.419625ms, 57.064292ms, 107.507167ms, 205.444042ms, 400.657375ms, 806.92825ms, 1.586994042s]

Sequential results:


Number of transactions: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
Time to create merkle tree: [49.792µs, 107.417µs, 192.208µs, 403.292µs, 853.625µs, 1.566ms, 3.076375ms, 6.152083ms, 12.446291ms, 24.475333ms, 50.433583ms, 101.566292ms, 208.53025ms, 401.385792ms, 795.495041ms, 1.592332875s, 3.228540584s]